### PR TITLE
Notification API permission fix

### DIFF
--- a/upload/js/liveupdate/update.js
+++ b/upload/js/liveupdate/update.js
@@ -99,8 +99,9 @@ var LiveUpdate = {};
 			document.title = pageTitle;
 		}
 	};
+	
 
-	LiveUpdate.Notification = null;
+	LiveUpdate.Notification = Notification; 
 
 	LiveUpdate.SetupNotificationAPI = function()
 	{


### PR DESCRIPTION
Now notification api does not asking for permission because "LiveUpdate.Notification" is not defined. IDK how to fix it right way but with this change its works at least:)